### PR TITLE
Discord所蔵情報の取得元をBotAPIに変更

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -23,6 +23,7 @@ export default defineNuxtConfig({
       secret: process.env.JWT_SECRET
     },
     discord: {
+      botToken: process.env.DISCORD_BOT_TOKEN,
       clientID: process.env.DISCORD_CLIENT_ID,
       callbackURI: process.env.DISCORD_CALLBACK_URI,
       clientSecret: process.env.DISCORD_CLIENT_SECRET,

--- a/pages/admin/index.vue
+++ b/pages/admin/index.vue
@@ -21,6 +21,7 @@ console.log(members)
         <th>学籍番号</th>
         <th>LINE</th>
         <th>Discord</th>
+        <th>Joined</th>
         <th>Nickname</th>
         <th>Role</th>
       </tr>
@@ -34,6 +35,9 @@ console.log(members)
         <td>
           <img :src="m.discord_picture_url" alt="" />
           {{ m.discord_username }}
+        </td>
+        <td>
+          {{ m.discord_on_server ? '✅' : '❌' }}
         </td>
         <td>
           {{ m.discord_nickname }}

--- a/server/api/admin/members.ts
+++ b/server/api/admin/members.ts
@@ -35,19 +35,28 @@ export default defineEventHandler(async (event) => {
     const targetDiscordMemberData = guildMembersData.find((member) => {
       return member.user?.id == userdataFromDB.discord_service_id
     })
-    exportData.discord_username = targetDiscordMemberData?.user?.username!
-    exportData.discord_nickname = targetDiscordMemberData?.nick
-    exportData.discord_member_role = targetDiscordMemberData?.roles.some(
-      (role) => {
-        return role === memberRoleID
-      }
-    )!
-    exportData.discord_picture_url =
-      'https://cdn.discordapp.com/avatars/' +
-        targetDiscordMemberData?.user?.id +
-        '/' +
-        targetDiscordMemberData?.avatar ??
-      targetDiscordMemberData?.user?.avatar + '.png'
+    if (targetDiscordMemberData) {
+      exportData.discord_username = targetDiscordMemberData?.user?.username!
+      exportData.discord_nickname = targetDiscordMemberData?.nick
+      exportData.discord_member_role = targetDiscordMemberData?.roles.some(
+        (role) => {
+          return role == memberRoleID
+        }
+      )!
+      exportData.discord_picture_url =
+        'https://cdn.discordapp.com/avatars/' +
+          targetDiscordMemberData?.user?.id +
+          '/' +
+          targetDiscordMemberData?.avatar ??
+        targetDiscordMemberData?.user?.avatar + '.png'
+      exportData.discord_on_server = true
+    } else {
+      exportData.discord_username = 'unknown'
+      exportData.discord_nickname = 'unknown'
+      exportData.discord_member_role = false
+      exportData.discord_picture_url = ''
+      exportData.discord_on_server = false
+    }
     exportData.line_username = userdataFromDB.line_username
     exportData.line_picture_url = userdataFromDB.line_picture_url
     exportData.student_id = userdataFromDB.student_id

--- a/server/api/admin/members.ts
+++ b/server/api/admin/members.ts
@@ -43,12 +43,14 @@ export default defineEventHandler(async (event) => {
           return role == memberRoleID
         }
       )!
+      console.log(targetDiscordMemberData?.avatar)
       exportData.discord_picture_url =
         'https://cdn.discordapp.com/avatars/' +
-          targetDiscordMemberData?.user?.id +
-          '/' +
-          targetDiscordMemberData?.avatar ??
-        targetDiscordMemberData?.user?.avatar + '.png'
+        targetDiscordMemberData?.user?.id +
+        '/' +
+        (String(targetDiscordMemberData?.avatar) !== 'null'
+          ? targetDiscordMemberData?.avatar
+          : targetDiscordMemberData?.user?.avatar)
       exportData.discord_on_server = true
     } else {
       exportData.discord_username = userdataFromDB.discord_username

--- a/server/api/admin/members.ts
+++ b/server/api/admin/members.ts
@@ -1,10 +1,14 @@
 import admin from '~/server/pkg/firebase-admin'
 import { User } from '~/server/types/user'
 import { UserProfile } from '~/server/types/user_profile'
+import { listGuildMembers } from '~/server/pkg/discord/api-bot'
 
 const db = admin.firestore()
+const targetGuildID = useRuntimeConfig().discord.guildID
+const memberRoleID = Number(useRuntimeConfig().discord.memberRoleID)
 
 export default defineEventHandler(async (event) => {
+  // access authorization check starts from here
   const userID = event.context.userID
   if (!userID) {
     return sendError(event, new Error('invalid token'))
@@ -17,20 +21,38 @@ export default defineEventHandler(async (event) => {
   if (!userData.has_access) {
     return sendError(event, new Error('user has no access'))
   }
+  // access authorization check ends here
+
+  const guildMembersData = await listGuildMembers(targetGuildID)
+  if (!guildMembersData) {
+    return sendError(event, new Error('failed to get guild members'))
+  }
   const usersSnapshot = await db.collection('users').orderBy('student_id').get()
   const users: UserProfile[] = []
   await usersSnapshot.forEach((doc) => {
     const exportData = {} as UserProfile
-    const targetData = doc.data() as User
-    exportData.discord_username = targetData.discord_username
-    exportData.discord_nickname = targetData.discord_nickname
-    exportData.discord_member_role = targetData.discord_member_role
-    exportData.discord_picture_url = targetData.discord_picture_url
-    exportData.line_username = targetData.line_username
-    exportData.line_picture_url = targetData.line_picture_url
-    exportData.student_id = targetData.student_id
-    exportData.first_name = targetData.first_name
-    exportData.last_name = targetData.last_name
+    const userdataFromDB = doc.data() as User
+    const targetDiscordMemberData = guildMembersData.find((member) => {
+      return member.user?.id == userdataFromDB.discord_service_id
+    })
+    exportData.discord_username = targetDiscordMemberData?.user?.username!
+    exportData.discord_nickname = targetDiscordMemberData?.nick
+    exportData.discord_member_role = targetDiscordMemberData?.roles.some(
+      (role) => {
+        return role === memberRoleID
+      }
+    )!
+    exportData.discord_picture_url =
+      'https://cdn.discordapp.com/avatars/' +
+        targetDiscordMemberData?.user?.id +
+        '/' +
+        targetDiscordMemberData?.avatar ??
+      targetDiscordMemberData?.user?.avatar + '.png'
+    exportData.line_username = userdataFromDB.line_username
+    exportData.line_picture_url = userdataFromDB.line_picture_url
+    exportData.student_id = userdataFromDB.student_id
+    exportData.first_name = userdataFromDB.first_name
+    exportData.last_name = userdataFromDB.last_name
     users.push(exportData)
   })
   return users

--- a/server/api/admin/members.ts
+++ b/server/api/admin/members.ts
@@ -51,8 +51,8 @@ export default defineEventHandler(async (event) => {
         targetDiscordMemberData?.user?.avatar + '.png'
       exportData.discord_on_server = true
     } else {
-      exportData.discord_username = 'unknown'
-      exportData.discord_nickname = 'unknown'
+      exportData.discord_username = userdataFromDB.discord_username
+      exportData.discord_nickname = ''
       exportData.discord_member_role = false
       exportData.discord_picture_url = ''
       exportData.discord_on_server = false

--- a/server/api/auth-discord.ts
+++ b/server/api/auth-discord.ts
@@ -84,6 +84,7 @@ async function createUser(
   userResp: DiscordUserResponse
 ): Promise<string> {
   const newUser: User = {} as User
+  newUser.discord_username = userResp.username
   newUser.discord_service_id = userResp.id
   newUser.discord_access_token = tokenResp.access_token
   newUser.discord_refresh_token = tokenResp.refresh_token

--- a/server/api/auth-discord.ts
+++ b/server/api/auth-discord.ts
@@ -4,7 +4,7 @@ import {
   getAccessToken,
   getDiscordServerInfo,
   getDiscordUserInfo
-} from '~/server/pkg/discord-auth'
+} from '~/server/pkg/discord/api-user'
 import { DiscordUserResponse } from '~/server/types/api/discord-api/discord-user'
 import { DiscordAccessTokenResponse } from '~/server/types/api/discord-api/discord-token'
 import { generateToken } from '~/server/pkg/jwt'

--- a/server/api/refresh.ts
+++ b/server/api/refresh.ts
@@ -1,7 +1,6 @@
 import admin from '~/server/pkg/firebase-admin'
 import { User } from '~/server/types/user'
 import {
-  getDiscordServerInfo,
   getDiscordUserInfo,
   refreshDiscordToken
 } from '~/server/pkg/discord/api-user'
@@ -42,31 +41,9 @@ async function updateUsers(): Promise<string[]> {
       continue
     }
     const updateData = {
-      discord_username:
-        discordProfile.username + ' #' + discordProfile.discriminator,
-      discord_nickname: '',
-      discord_service_id: discordProfile.id,
       discord_access_token: newToken.access_token,
       discord_refresh_token: newToken.refresh_token,
-      discord_expires_at: Math.floor(Date.now() / 1000) + newToken.expires_in,
-      discord_picture_url:
-        'https://cdn.discordapp.com/avatars/' +
-        discordProfile.id +
-        '/' +
-        discordProfile.avatar +
-        '.png',
-      discord_member_role: false
-    }
-
-    const discordServerMemberInfo = await getDiscordServerInfo(
-      newToken.access_token
-    )
-    if (discordServerMemberInfo && discordServerMemberInfo.nick) {
-      updateData.discord_nickname = discordServerMemberInfo.nick
-      updateData.discord_member_role =
-        discordServerMemberInfo.roles?.findIndex(
-          (value) => value == memberRoleID
-        ) > -1
+      discord_expires_at: Math.floor(Date.now() / 1000) + newToken.expires_in
     }
 
     const refreshReq = await db

--- a/server/api/refresh.ts
+++ b/server/api/refresh.ts
@@ -41,6 +41,8 @@ async function updateUsers(): Promise<string[]> {
       continue
     }
     const updateData = {
+      discord_username: discordProfile.username,
+      discord_service_id: discordProfile.id,
       discord_access_token: newToken.access_token,
       discord_refresh_token: newToken.refresh_token,
       discord_expires_at: Math.floor(Date.now() / 1000) + newToken.expires_in

--- a/server/api/refresh.ts
+++ b/server/api/refresh.ts
@@ -4,7 +4,7 @@ import {
   getDiscordServerInfo,
   getDiscordUserInfo,
   refreshDiscordToken
-} from '~/server/pkg/discord-auth'
+} from '~/server/pkg/discord/api-user'
 
 const db = admin.firestore()
 

--- a/server/pkg/discord/api-bot.ts
+++ b/server/pkg/discord/api-bot.ts
@@ -1,0 +1,32 @@
+import { DiscordMemberInfoResponse } from '~/server/types/api/discord-api/discord-member-info'
+import axios from 'axios'
+
+const token = useRuntimeConfig().discord.botToken
+
+async function listGuildMembers(
+  id: string
+): Promise<DiscordMemberInfoResponse[] | null> {
+  const endpoint = `https://discord.com/api/guilds/${id}/members`
+  return axios
+    .get(endpoint, {
+      params: {
+        limit: 1000
+      },
+      headers: {
+        Authorization: 'Bot ' + token
+      }
+    })
+    .then((response) => {
+      return response.data as DiscordMemberInfoResponse[]
+    })
+    .catch((error) => {
+      console.log(
+        'listGuildMembers failed (status, error): ',
+        error.response.status,
+        error.response.data
+      )
+      return null
+    })
+}
+
+export { listGuildMembers }

--- a/server/pkg/discord/api-user.ts
+++ b/server/pkg/discord/api-user.ts
@@ -118,29 +118,6 @@ async function refreshDiscordToken(
     })
 }
 
-async function listGuildMembers(
-  token: string
-): Promise<DiscordUserResponse | null> {
-  const url: string = 'https://discordapp.com/api/users/@me'
-  return await axios
-    .get(url, {
-      headers: {
-        Authorization: 'Bearer ' + token
-      }
-    })
-    .then((response) => {
-      return response.data as DiscordUserResponse
-    })
-    .catch((error) => {
-      console.log(
-        'getDiscordUserInfo failed (status, error): ',
-        error.response.status,
-        error.response.data
-      )
-      return null
-    })
-}
-
 export {
   getAccessToken,
   getDiscordUserInfo,

--- a/server/types/api/discord-api/discord-member-info.ts
+++ b/server/types/api/discord-api/discord-member-info.ts
@@ -1,5 +1,5 @@
 export interface DiscordMemberInfoResponse {
-  avatar?: boolean
+  avatar?: string
   communication_disabled_until?: boolean
   flags: number
   joined_at: string

--- a/server/types/user.ts
+++ b/server/types/user.ts
@@ -9,13 +9,9 @@ export interface User {
   line_refresh_token: string
   line_expires_at: number
   line_picture_url: string
-  discord_username: string
-  discord_nickname?: string
-  discord_member_role: boolean
   discord_service_id: string
   discord_access_token: string
   discord_refresh_token: string
   discord_expires_at: number
-  discord_picture_url: string
   has_access: boolean
 }

--- a/server/types/user.ts
+++ b/server/types/user.ts
@@ -9,6 +9,7 @@ export interface User {
   line_refresh_token: string
   line_expires_at: number
   line_picture_url: string
+  discord_username: string
   discord_service_id: string
   discord_access_token: string
   discord_refresh_token: string

--- a/server/types/user_profile.ts
+++ b/server/types/user_profile.ts
@@ -4,8 +4,9 @@ export interface UserProfile {
   student_id: number
   discord_username: string
   discord_nickname?: string
-  discord_member_role: boolean
   discord_picture_url: string
+  discord_member_role: boolean
+  discord_on_server: boolean
   line_username: string
   line_picture_url: string
   has_access: boolean

--- a/types/user_profile.ts
+++ b/types/user_profile.ts
@@ -5,10 +5,11 @@ export interface UserProfile {
   discord_username?: string
   discord_nickname?: string
   discord_picture_url?: string
+  discord_member_role?: boolean
+  discord_on_server?: boolean
   line_username?: string
   line_picture_url?: string
   has_access?: boolean
-  discord_member_role?: boolean
 }
 
 export function fulfillsRequirements(userProfile: UserProfile): boolean {


### PR DESCRIPTION
- 🚚 discord-auth.ts -> discord/api-user.ts
- 🎨 refresh api内でupdateUsersを分離
- 🔧 add DISCORD_BOT_TOKEN to nuxt.config.ts
- ✨ discord/api-bot.ts, listGuildMembers
- 🗃️ discord_username, discord_nickname, discord_member_role, discord_picture_urlをDB保存対象から削除
- ⚡️ discordの一部データの取得元をDBからAPIに変更
- 🔥 Server情報,Avatar情報の更新処理を排除
- 🔥 認証時のServer情報/メンバー情報の登録処理を削除
- ✨ Joinedフィールドの追加(discord_on_server)
- 🗃️ discord_usernameフィールド保存の復活

# やったこと
Discordの所属情報を、いままではUserScopeのAPIで定期的に取得し、保存された情報を使用していたが、
BotScopeでサーバーのメンバーリストを取得して毎回その情報を利用する形に変更した。
また、これに伴いDBに保存する情報からNickNameやAvatar画像等を排除した。