### PR TITLE
global_name 表示対応

### DIFF
--- a/pages/admin/index.vue
+++ b/pages/admin/index.vue
@@ -34,7 +34,7 @@ console.log(members)
         </td>
         <td>
           <img :src="m.discord_picture_url" alt="" />
-          {{ m.discord_username }}
+          {{ m.discord_global_name ?? m.discord_username }}
         </td>
         <td>
           {{ m.discord_on_server ? '✅' : '❌' }}

--- a/server/api/admin/members.ts
+++ b/server/api/admin/members.ts
@@ -32,25 +32,23 @@ export default defineEventHandler(async (event) => {
   await usersSnapshot.forEach((doc) => {
     const exportData = {} as UserProfile
     const userdataFromDB = doc.data() as User
-    const targetDiscordMemberData = guildMembersData.find((member) => {
+    const discordMemberData = guildMembersData.find((member) => {
       return member.user?.id == userdataFromDB.discord_service_id
     })
-    if (targetDiscordMemberData) {
-      exportData.discord_username = targetDiscordMemberData?.user?.username!
-      exportData.discord_nickname = targetDiscordMemberData?.nick
-      exportData.discord_member_role = targetDiscordMemberData?.roles.some(
-        (role) => {
-          return role == memberRoleID
-        }
-      )!
-      console.log(targetDiscordMemberData?.avatar)
+    if (discordMemberData) {
+      exportData.discord_username = discordMemberData.user?.username!
+      exportData.discord_global_name = discordMemberData.user?.global_name
+      exportData.discord_nickname = discordMemberData.nick
+      exportData.discord_member_role = discordMemberData.roles.some((role) => {
+        return role == memberRoleID
+      })!
       exportData.discord_picture_url =
         'https://cdn.discordapp.com/avatars/' +
-        targetDiscordMemberData?.user?.id +
+        discordMemberData.user?.id +
         '/' +
-        (String(targetDiscordMemberData?.avatar) !== 'null'
-          ? targetDiscordMemberData?.avatar
-          : targetDiscordMemberData?.user?.avatar)
+        (String(discordMemberData.avatar) !== 'null'
+          ? discordMemberData.avatar
+          : discordMemberData.user?.avatar)
       exportData.discord_on_server = true
     } else {
       exportData.discord_username = userdataFromDB.discord_username

--- a/server/types/api/discord-api/discord-member-info.ts
+++ b/server/types/api/discord-api/discord-member-info.ts
@@ -10,8 +10,7 @@ export interface DiscordMemberInfoResponse {
   user?: {
     id: string
     username: string
-    global_name: boolean
-    display_name: boolean
+    global_name?: string
     avatar: string
     discriminator: string
     public_flags: number

--- a/server/types/user_profile.ts
+++ b/server/types/user_profile.ts
@@ -3,6 +3,7 @@ export interface UserProfile {
   last_name: string
   student_id: number
   discord_username: string
+  discord_global_name?: string
   discord_nickname?: string
   discord_picture_url: string
   discord_member_role: boolean

--- a/types/user_profile.ts
+++ b/types/user_profile.ts
@@ -3,6 +3,7 @@ export interface UserProfile {
   last_name?: string
   student_id?: number
   discord_username?: string
+  discord_global_name?: string
   discord_nickname?: string
   discord_picture_url?: string
   discord_member_role?: boolean


### PR DESCRIPTION
- ✨ (api/admin/members)global_name for discord
- ✨ (page/admin/members)global_name表記に対応

global_name属性が存在する場合に、global_nameをusernameの代わりに表示するようにした。